### PR TITLE
configure: avoid obsolete macros

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -31,7 +31,7 @@ AC_DEFUN([JH_PATH_XML_CATALOG],
 [
   # check for the presence of the XML catalog
   AC_ARG_WITH([xml-catalog],
-              AC_HELP_STRING([--with-xml-catalog=CATALOG],
+              AS_HELP_STRING([--with-xml-catalog=CATALOG],
                              [path to xml catalog to use]),,
               [with_xml_catalog=/etc/xml/catalog])
   jh_found_xmlcatalog=true

--- a/configure.ac
+++ b/configure.ac
@@ -729,14 +729,14 @@ AS_CASE([$host_os],
     AC_MSG_CHECKING([for SetupDiGetDevicePropertyW])
     ctk_save_LIBS="$LIBS"
     LIBS="-lsetupapi $LIBS"
-    AC_TRY_LINK(
-      [
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+      [[
 #define _WIN32_WINNT 0x0600
 #include <windows.h>
 #include <devpropdef.h>
 #include <setupapi.h>
-      ],
-      [return SetupDiGetDevicePropertyW(NULL, NULL, NULL, NULL, NULL, 0, NULL, 0);],
+      ]],
+      [[return SetupDiGetDevicePropertyW(NULL, NULL, NULL, NULL, NULL, 0, NULL, 0);]])],
       [have_SetupDiGetDevicePropertyW=yes],
       [have_SetupDiGetDevicePropertyW=no]
     )

--- a/configure.ac
+++ b/configure.ac
@@ -1810,11 +1810,12 @@ case "$host" in
     SAVED_CFLAGS="${CFLAGS}"
     CFLAGS="-fvisibility=hidden"
     AC_MSG_CHECKING([for -fvisibility=hidden compiler flag])
-    AC_TRY_COMPILE([], [return 0],
-                   AC_MSG_RESULT(yes)
-                   enable_fvisibility_hidden=yes,
-                   AC_MSG_RESULT(no)
-                   enable_fvisibility_hidden=no)
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[return 0]])],
+                      AC_MSG_RESULT(yes)
+                      enable_fvisibility_hidden=yes,
+                      AC_MSG_RESULT(no)
+                      enable_fvisibility_hidden=no)
+
     CFLAGS="${SAVED_CFLAGS}"
 
     AS_IF([test "${enable_fvisibility_hidden}" = "yes"], [

--- a/configure.ac
+++ b/configure.ac
@@ -1299,9 +1299,9 @@ if $PKG_CONFIG --uninstalled $PANGO_PACKAGES; then
 else
 	ctk_save_LIBS="$LIBS"
         LIBS="$PANGO_LIBS $LIBS"
-        AC_TRY_LINK_FUNC(pango_context_new, :, AC_MSG_ERROR([
+        AC_LINK_IFELSE([AC_LANG_CALL([], [pango_context_new])], [:], [AC_MSG_ERROR([
 *** Can't link to Pango. Pango is required to build
-*** CTK+. For more information see http://www.pango.org]))
+*** CTK+. For more information see http://www.pango.org])])
         LIBS="$ctk_save_LIBS"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1784,7 +1784,7 @@ else
 fi
 
 AC_ARG_ENABLE(doc-cross-references,
-              AC_HELP_STRING([--disable-doc-cross-references],
+              AS_HELP_STRING([--disable-doc-cross-references],
                              [cross reference symbols from other libraries @<:@default=yes@:>@]),
               enable_doc_cross_references=$enableval,
               enable_doc_cross_references=yes)


### PR DESCRIPTION
https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/Obsolete-Macros.html