### PR TITLE
Add support for font filtering in CtkFontSelection

### DIFF
--- a/ctk/deprecated/ctkfontsel.c
+++ b/ctk/deprecated/ctkfontsel.c
@@ -836,7 +836,6 @@ ctk_font_selection_show_available_fonts (CtkFontSelection *fontsel)
 				goto fontsel_addfamily;
 			}
 		}
-		return;
     } else {
 		fontsel_addfamily:
 		{

--- a/ctk/deprecated/ctkfontsel.c
+++ b/ctk/deprecated/ctkfontsel.c
@@ -54,6 +54,7 @@
 #include "ctkorientable.h"
 #include "ctkprivate.h"
 #include "ctkfontsel.h"
+#include "ctkfontchooser.h"
 
 /**
  * SECTION:ctkfontsel

--- a/ctk/deprecated/ctkfontsel.h
+++ b/ctk/deprecated/ctkfontsel.h
@@ -137,6 +137,12 @@ CDK_DEPRECATED_IN_3_2_FOR(CtkFontChooser)
 void         ctk_font_selection_set_preview_text  (CtkFontSelection *fontsel,
                                                    const gchar      *text);
 
+/* These are all private functions intended to be used by CtkFontChooserWidget, dont export these. */
+void         ctk_font_selection_set_filter_func (GtkFontSelection *fontsel,
+                                         GtkFontFilterFunc filter,
+                                         gpointer          data,
+                                         GDestroyNotify    destroy);
+
 CDK_DEPRECATED_IN_3_2
 GType      ctk_font_selection_dialog_get_type          (void) G_GNUC_CONST;
 CDK_DEPRECATED_IN_3_2_FOR(CtkFontChooser)

--- a/ctk/deprecated/ctkfontsel.h
+++ b/ctk/deprecated/ctkfontsel.h
@@ -36,6 +36,7 @@
 
 #include <ctk/ctkdialog.h>
 #include <ctk/ctkbox.h>
+#include <ctk/ctkfontchooser.h>
 
 
 G_BEGIN_DECLS

--- a/ctk/deprecated/ctkfontsel.h
+++ b/ctk/deprecated/ctkfontsel.h
@@ -138,8 +138,8 @@ void         ctk_font_selection_set_preview_text  (CtkFontSelection *fontsel,
                                                    const gchar      *text);
 
 /* These are all private functions intended to be used by CtkFontChooserWidget, dont export these. */
-void         ctk_font_selection_set_filter_func (GtkFontSelection *fontsel,
-                                         GtkFontFilterFunc filter,
+void         ctk_font_selection_set_filter_func (CtkFontSelection *fontsel,
+                                         CtkFontFilterFunc filter,
                                          gpointer          data,
                                          GDestroyNotify    destroy);
 


### PR DESCRIPTION
This is prep work for the patch that will wrap the CtkFontChooserWidget around CtkFontSelection in order to gain a more conservative, GTK2 esque look and feel in CTK applications that use the newer CtkFontChooser API.